### PR TITLE
Try to use BibTeX for references

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,7 @@ authors = ["Abel Soares Siqueira <abel.s.siqueira@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Bibliography = "f1be7e48-bf82-45af-a471-ae754a193061"
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"

--- a/_data/bibtex/articles2019.bib
+++ b/_data/bibtex/articles2019.bib
@@ -1,0 +1,55 @@
+@article{estrin-orban-saunders-2019c,
+  author = {{\student R. Estrin} and Orban, D. and Saunders, M. A.},
+  title = {LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property},
+  year = {2019},
+  journal = {SIAM Journal on Matrix Analysis},
+  volume = {40},
+  number = {3},
+  pages = {1102--1124},
+  grant = {NSERC 299010-04},
+  preprint = {https://dx.doi.org/10.13140/RG.2.2.34725.81123},
+  gerad = {G-2018-40},
+  doi = {10.1137/18M1194948}
+}
+
+@article{buttari-orban-ruiz-titley-peloquin-2019,
+  author = {Buttari, A. and Orban, D. and Ruiz, D. and Titley-Peloquin, D.},
+  title = {A Tridiagonalization Method for Symmetric Saddle-Point System},
+  year = {2019},
+  journal = {SIAM Journal on Scientific Computing},
+  volume = {41},
+  number = {5},
+  pages = {S409--S432},
+  grant = {NSERC 299010-04},
+  preprint = {https://www.gerad.ca/en/papers/G-2018-42/view},
+  gerad = {G-2018-42},
+  doi = {10.1137/18M1194900}
+}
+
+@article{dahito-orban-2019,
+  author = {{Marie-Ange Dahito} and Orban, D.},
+  title = {The Conjugate Residual Method in Linesearch and Trust-Region Methods},
+  journal = {SIAM Journal on Optimization},
+  volume = {29},
+  number = {3},
+  year = {2019},
+  pages = {1988--2025},
+  grant = {NSERC 299010-04},
+  preprint = {https://www.gerad.ca/en/papers/G-2018-50/view},
+  gerad = {G-2018-50},
+  doi = {10.1137/18M1204255}
+}
+
+@article{estrin-orban-saunders-2019b,
+  author = {{R. Estrin} and Orban, D. and Saunders, M. A.},
+  title = {LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property},
+  year = {2019},
+  journal = {SIAM Journal on Matrix Analysis},
+  volume = {40},
+  number = {1},
+  pages = {254--275},
+  grant = {NSERC 299010-04},
+  preprint = {https://goo.gl/uyPRk5},
+  gerad = {G-2017-05},
+  doi = {10.1137/17M1113552}
+}

--- a/_data/bibtex/articles2020.bib
+++ b/_data/bibtex/articles2020.bib
@@ -1,0 +1,11 @@
+@article{orban-siqueira-2020,
+  author = {Orban, D. and Siqueira, A. S.},
+  title = {A Regularization Method for Constrained Nonlinear Least Squares},
+  year = {2020},
+  journal = {Computational Optimization and Applications},
+  volume = {76},
+  number = {},
+  pages = {961--989},
+  preprint = {https://www.gerad.ca/en/papers/G-2019-17/view},
+  doi = {10.1007/s10589-020-00201-2}
+}

--- a/_data/bibtex/books2017.bib
+++ b/_data/bibtex/books2017.bib
@@ -1,0 +1,13 @@
+@book{orban-arioli-2017,
+  author = {Orban, D. and Arioli, M.},
+  title = {Iterative Solution of Symmetric Quasi-Definite Linear Systems},
+  publisher = {SIAM},
+  year = {2017},
+  optkey = {},
+  volume = {3},
+  optnumber = {},
+  series = {Spotlights},
+  optaddress = {Philadelphia, PA},
+  optedition = {},
+  doi = {10.1137/1.9781611974737}
+}

--- a/_data/references.json
+++ b/_data/references.json
@@ -5,7 +5,7 @@
     "date": "2017-12-01",
     "where": "Seminários de Análise Convexa e Otimização. UFSC, Florianópolis/SC, Brasil",
     "link": "http://abelsiqueira.github.io/assets/2017-12-01-ufsc.pdf",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "A Workflow for Designing Optimization Methods in the Julia Language",
@@ -13,7 +13,7 @@
     "date": "2016-05-04",
     "where": "2016 Optimization Days. Montréal, Canada",
     "link": "http://abelsiqueira.github.io/assets/jopt-2016.pdf",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "Advanced Topics in Scientific Computing with Julia",
@@ -21,14 +21,14 @@
     "where": "Stanford University",
     "date": "2018-03-03",
     "link": "https://github.com/icme/cme257-advanced-julia",
-    "key": "Classes"
+    "type": "classes"
   },
   {
     "title": "Otimização I",
     "author": "Abel S. Siqueira",
     "where": "UFPR - Federal University of Paraná",
     "date": "2018-06-19",
-    "key": "Classes"
+    "type": "classes"
   },
   {
     "title": "Developing new optimization methods with packages from the JuliaSmoothOptimizers organization",
@@ -36,14 +36,14 @@
     "where": "Second Annual JuMP-dev Workshop. Bordeaux, France",
     "date": "2018-06-28",
     "link": "http://abelsiqueira.github.io/assets/2018-06-28-jump-dev.pdf",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "Iterative Methods with an Error Minimization Property",
     "author": "Dominique Orban, Ron Estrin and Michael A. Saunders",
     "where": "LA/Opt Seminar, ICME, Stanford University",
     "date": "2018-05-31",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "A Regularized Interior-Point Method for Constrained Nonlinear Least Squares",
@@ -51,47 +51,7 @@
     "where": "XII Brazilian Workshop on Continuous Optimization. Iguaçu Falls, Brazil.",
     "date": "2018-07-23",
     "link": "http://abelsiqueira.github.io/assets/2018-07-23-xiibrazopt.pdf",
-    "key": "Talks"
-  },
-  {
-    "title": "The Conjugate Residual Method in Linesearch and Trust-Region Methods",
-    "author": "M.-A. Dahito and D. Orban",
-    "where": "SIAM Journal On Optimization, 29(3), 1988–2025",
-    "date": "2019-07-25",
-    "link": "https://doi.org/10.1137/18M1204255",
-    "key": "Publications"
-  },
-  {
-    "title": "LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property",
-    "author": "R. Estrin, D. Orban and M. A. Saunders",
-    "where": "SIAM Journal On Matrix Analysis, 40(3), 1102–1124",
-    "date": "2019-11-12",
-    "link": "https://doi.org/10.1137/18M1194948",
-    "key": "Publications"
-  },
-  {
-    "title": "A Tridiagonalization Method for Symmetric Saddle-Point System",
-    "author": "A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin",
-    "where": "SIAM Journal On Scientific Computing, 41(5), S409–S432",
-    "date": "2019-10-29",
-    "link": "https://doi.org/10.1137/18M1194900",
-    "key": "Publications"
-  },
-  {
-    "title": "Iterative Solution of Symmetric Quasi-Definite Linear Systems",
-    "author": "D. Orban and M. Arioli",
-    "where": "Society for Industrial and Applied Mathematics",
-    "date": "2017-04-01",
-    "link": "https://doi.org/10.1137/1.9781611974737",
-    "key": "Books"
-  },
-  {
-    "title": "LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property",
-    "author": "R. Estrin, D. Orban and M. A. Saunders",
-    "where": "SIAM Journal On Matrix Analysis, 40(1), 254-275",
-    "date": "2019-02-14",
-    "link": "https://dx.doi.org/10.1137/17M1113552",
-    "key": "Publications"
+    "type": "talk"
   },
   {
     "title": "Méthodes d'optimisation et contrôle optimal",
@@ -99,15 +59,7 @@
     "where": "Polytechnique Montréal",
     "date": "2019-01-01",
     "link": "https://www.polymtl.ca/programmes/cours/methodes-doptimisation-et-controle-optimal",
-    "key": "Classes"
-  },
-  {
-    "title": "A regularization method for constrained nonlinear least squares",
-    "author": "Dominique Orban and Abel Soares Siqueira",
-    "where": "Computational Optimization and Applications, 76, 961-989",
-    "date": "2020-07-01",
-    "link": "https://doi.org/10.1007/s10589-020-00201-2",
-    "key": "Publications"
+    "type": "classes"
   },
   {
     "title": "JuliaSmoothOptimizers",
@@ -115,7 +67,7 @@
     "date": "2019-02-07",
     "where": "Tutorial: Modeling and optimization tools in Julia: An introduction to JuMP and JSO. GERAD. Montreal/QC, Canada",
     "link": "http://abelsiqueira.github.io/assets/2019-02-07-GERAD.tar.gz",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "JuliaSmoothOptimizers",
@@ -123,7 +75,7 @@
     "date": "2019-05-31",
     "where": "Talk at PPGM - UFPR. Curitiba/PR, Brazil.",
     "link": "http://abelsiqueira.github.io/assets/2019-05-31-PPGM.ipynb",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "Otimização na Linguagem Julia",
@@ -131,7 +83,7 @@
     "date": "2019-06-26",
     "where": "Palestra no Congresso Internacional de Biomassa - 4° Expo Biomassa - Curitiba/PR, Brazil.",
     "link": "https://docs.google.com/presentation/d/e/2PACX-1vTExSw03IXqsEOOjWeFvvC0FLodFUw5RpIQJLNUALql9jWPjS6GG4fyVeRn3BqehrT5AmfpWYvR4Tpo/pub?start=true&loop=false&delayms=5000&slide=id.g5c57578bdc_0_1264",
-    "key": "Talks"
+    "type": "talk"
   },
   {
     "title": "Algèbre linéaire numérique appliquée",
@@ -139,7 +91,7 @@
     "where": "Polytechnique Montréal",
     "date": "2021-01-01",
     "link": "https://www.polymtl.ca/programmes/cours/algebre-lineaire-numerique-appliquee",
-    "key": "Classes"
+    "type": "classes"
   },
   {
     "title": "Otimização Não Linear em Julia",
@@ -147,6 +99,6 @@
     "where": "YouTube",
     "date": "2020-09-02",
     "link": "https://www.youtube.com/playlist?list=PLOOY0eChA1ux1LAmJZNBySGeqR0kwNZmQ",
-    "key": "Classes"
+    "type": "classes"
   }
 ]

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -61,4 +61,29 @@ pre {
   transition: 200ms;
 }
 
+.copy-ref {
+  border-width: 0px !important;
+  background-color: transparent !important;
+  transition: 200ms;
+  padding: 2px !important;
+
+  :hover {
+    background-color: $primary;
+    transition: 200ms;
+  }
+}
+
+.copy-ref span {
+  transition: 200ms;
+  padding: 2px !important;
+  :hover {
+    color: $julia-background;
+    transition: 200ms;
+  }
+}
+
+.references ul li {
+  margin-bottom: 15px;
+}
+
 @import "../node_modules/bulma/bulma.sass";

--- a/references.md
+++ b/references.md
@@ -1,5 +1,11 @@
 @def title = "References"
 
+~~~
+<script>
+new ClipboardJS('.copy-ref');
+</script>
+~~~
+
 # Publications, talks and other references
 
 If you use JSO, we ask that you cite us. In addition to any specific reference that may suggested by the packages you are using, we also ask you to cite:
@@ -17,21 +23,83 @@ If you use JSO, we ask that you cite us. In addition to any specific reference t
 
 ```julia:./list-publications.jl
 #hideall
-using JSON
-data = JSON.parsefile("_data/bib.json")
-data = sort(data, by=x->x["date"], rev=true)
-for key in ["Books", "Publications", "Talks", "Classes"]
-  println("### $key")
-  for d in filter(x -> x["key"] == key, data)
-    url = get(d, "link", nothing)
-    if url === nothing
-      print("- $(d["title"]), ")
-    else
-      print("- [$(d["title"])]($url), ")
-    end
-    D = Dates.format(Date(d["date"]), "yyyy-u-d")
-    println(join([d["author"], "_$(D)_", d["where"]], ", "))
+using Bibliography, JSON
+
+function bib_string(
+  authors,
+  title,
+  where,
+  date,
+  link=nothing;
+  isdoi=false,
+)
+  if !isdoi && link != nothing
+    title = "[$title]($link)"
+  end
+  V = [title, "**$(authors)**", where]
+  if date != ""
+    push!(V, date)
+  end
+  if isdoi
+    push!(V, "[$link]($link)")
+  end
+  str = join(V, ", ")
+  str = replace(str, "{" => "", "}" => "", "\\'e" => "é", "\\student" => "", "https://doi.org/" => "")
+  return str
+end
+
+function icon(cite)
+  """~~~
+  <button data-clipboard-text="$(cite)" class="copy-ref">
+  <span class="icon is-small has-text-primary">
+  <ion-icon size="small" name="copy"></ion-icon>
+  </span>
+  </button>
+  ~~~"""
+end
+
+bib = vcat(bibtex_to_web.("_data/bibtex/" .* readdir("_data/bibtex/"))...)
+json = JSON.parsefile("_data/references.json")
+json = sort(json, by=x->x["date"], rev=true)
+
+for (type_, title) in [
+    ("book", "Books"),
+    ("article", "Articles"),
+    ("techreport", "Technical Reports")
+  ]
+  selected = sort(filter(x -> x.type == type_, bib), by=x -> x.year)
+  length(selected) == 0 && continue
+
+  println("### $title")
+
+  for v in selected
+    str = bib_string(v.names, v.title, v.in, "", v.link, isdoi=true)
+
+
+    println("- " * icon(v.cite) * str)
+  end
+end
+
+for (type_, title) in [
+    ("talk", "Talks"),
+    ("classes", "Classes"),
+  ]
+  selected = filter(x -> x["type"] == type_, json)
+  length(selected) == 0 && continue
+
+  println("### $title")
+
+  for v in selected
+    str = bib_string(v["author"], v["title"], v["where"], Dates.format(Date(v["date"]), "yyyy-u-d"), get(v, "link", nothing))
+    println("- " * str)
   end
 end
 ```
-\textoutput{./list-publications}
+
+~~~
+<div class="references">
+~~~
+\textoutput{./list-publications.jl}
+~~~
+</div>
+~~~


### PR DESCRIPTION
Working on #9.

@dpo, a few issues with the BibTeX implementation. In some situations, the bib file is not read correctly. I can't precise where, because I tried a few things. I copied some papers from your page, modified them until this worked, and added them here.
The other issue is that I have found no formatting package, so I have to produce the final reference manually.
I built it in a way that does not stop using JSON because I don't see a reason to move the talks and classes to BibTeX. And, at the moment, I am leaving the entries at both BibTeX and JSON, so we can compare the outputs.

The only good news is that I learned how to write the "copy the BibTeX" button (from #10), so we can support that now. This feature is independent of the BibTeX file support because we can provide the BibTeX of an entry without parsing it, which is easier.

Questions:
- Is this what you were looking for?
- Does it simplify your usage?
- Would you still use it if you had to edit the files before submitting them here (e.g., removing \student and {...} around acronyms)?
- Is the formatting ok? If not, do you have someone willing to take care of improving it? (At least for `book`, `article` and `techreport` keys).

The preview should be ready in minutes.